### PR TITLE
feat: Github & Linkedin Buttons Added

### DIFF
--- a/components/lab/button/ButtonHoverGithubIcon.tsx
+++ b/components/lab/button/ButtonHoverGithubIcon.tsx
@@ -1,0 +1,27 @@
+const ButtonHoverGithubIcon = () => {
+  return (
+    <div className='group relative'>
+      <button>
+        <svg
+          stroke='currentColor'
+          fill='none'
+          viewBox='0 0 24 24'
+          className='w-8 text-white duration-200 hover:scale-125 hover:stroke-blue-500'
+        >
+          <path d='M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22'></path>
+        </svg>
+      </button>
+      <span
+        className='absolute -top-14 left-[50%] z-20 
+  origin-left -translate-x-[50%] scale-0 rounded-lg border border-gray-300 
+  bg-white px-3 py-2 text-sm font-bold
+  shadow-md transition-all duration-300 ease-in-out 
+  group-hover:scale-100'
+      >
+        GitHub<span></span>
+      </span>
+    </div>
+  );
+};
+
+export default ButtonHoverGithubIcon;

--- a/components/lab/button/ButtonHoverLinkedinIcon.tsx
+++ b/components/lab/button/ButtonHoverLinkedinIcon.tsx
@@ -1,0 +1,23 @@
+const ButtonHoverLinkedinIcon = () => {
+  return (
+    <button className='before:hover:500 group relative flex h-12 w-12 items-center justify-start gap-2 rounded bg-sky-700 p-2 pr-6 font-bold text-neutral-50 duration-700 before:absolute before:left-8 before:-z-10 before:h-6 before:w-6 before:rotate-45 before:bg-sky-700 before:duration-700 hover:w-44 hover:bg-sky-600 before:hover:left-40 before:hover:bg-sky-600'>
+      <svg
+        y='0'
+        xmlns='http://www.w3.org/2000/svg'
+        x='0'
+        width='100'
+        viewBox='0 0 100 100'
+        preserveAspectRatio='xMidYMid meet'
+        height='100'
+        className='h-8 w-8 shrink-0 fill-neutral-50'
+      >
+        <path d='M92.86,0H7.12A7.17,7.17,0,0,0,0,7.21V92.79A7.17,7.17,0,0,0,7.12,100H92.86A7.19,7.19,0,0,0,100,92.79V7.21A7.19,7.19,0,0,0,92.86,0ZM30.22,85.71H15.4V38H30.25V85.71ZM22.81,31.47a8.59,8.59,0,1,1,8.6-8.59A8.6,8.6,0,0,1,22.81,31.47Zm63,54.24H71V62.5c0-5.54-.11-12.66-7.7-12.66s-8.91,6-8.91,12.26V85.71H39.53V38H53.75v6.52H54c2-3.75,6.83-7.7,14-7.7,15,0,17.79,9.89,17.79,22.74Z'></path>
+      </svg>
+      <span className='inline-flex origin-left scale-x-0 transform border-l-2 px-1 opacity-0 transition-all duration-100 group-hover:scale-x-100 group-hover:opacity-100 group-hover:delay-500 group-hover:duration-300'>
+        Your Linkedin
+      </span>
+    </button>
+  );
+};
+
+export default ButtonHoverLinkedinIcon;

--- a/data/components.ts
+++ b/data/components.ts
@@ -6,6 +6,8 @@ import ButtonGradient from '@/components/lab/button/ButtonGradient';
 import ButtonHoverGradient from '@/components/lab/button/ButtonHoverGradient';
 import ButtonBackgroundSpotlight from '@/components/lab/button/ButtonBackgroundSpotlight';
 import ButtonRotatingBackgroundGradient from '@/components/lab/button/ButtonRotatingBackgroundGradient';
+import ButtonHoverGithubIcon from '@/components/lab/button/ButtonHoverGithubIcon';
+import ButtonHoverLinkedinIcon from '@/components/lab/button/ButtonHoverLinkedinIcon';
 import ButtonShadowGradient from '@/components/lab/button/ButtonShadowGradient';
 import InputGradientBorder from '@/components/lab/input/InputGradientBorder';
 import InputSpotlightBorder from '@/components/lab/input/InputSpotlightBorder';
@@ -116,6 +118,18 @@ export const COMPONENTS = [
     name: 'Button Shadow Gradient',
     component: ButtonShadowGradient,
     slug: 'button-shadow-gradient',
+    type: 'button',
+  },
+  {
+    name: 'Button Hover Github Icon',
+    component: ButtonHoverGithubIcon,
+    slug: 'button-hover-github-icon',
+    type: 'button',
+  },
+  {
+    name: 'Button Hover Linkedin Icon',
+    component: ButtonHoverLinkedinIcon,
+    slug: 'button-hover-linkedin-icon',
     type: 'button',
   },
   {


### PR DESCRIPTION
Added Github & Linkedin Buttons with Hover Effect

# Github - 

- before hovering-
![image](https://github.com/ibelick/ui-snippets/assets/48170773/68e2d2ac-1c21-42f9-8532-9a3a47b69aac)
- after hovering-
![image](https://github.com/ibelick/ui-snippets/assets/48170773/e1a19f24-4053-493a-a63b-af253bf25678)

# Linkedin -

- before hovering-
![image](https://github.com/ibelick/ui-snippets/assets/48170773/f7a0aa1b-54a3-4b1e-a64f-3128e1a63e9a)
- after hovering-
![image](https://github.com/ibelick/ui-snippets/assets/48170773/48d326d3-e7e1-45f0-880f-cfd6826c8665)

